### PR TITLE
Remove link to markmail from 'contribute' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,8 +148,7 @@
           To subscribe, send a blank email to <a href="mailto:dev-subscribe@fineract.apache.org">dev-subscribe@fineract.apache.org</a>.<br/>
           To <b>un</b>subscribe later, just send a blank email to <a href="mailto:dev-unsubscribe@fineract.apache.org">dev-unsubscribe@fineract.apache.org</a>.<br/>
           You can also read the archives 
-		<a href="https://lists.apache.org/list.html?dev@fineract.apache.org" target="_blank">on lists.apache.org</a>
-		or <a href="https://markmail.org/search/?q=list%3Aorg.apache.fineract.dev+order%3Adate-backward" target="_blank">on MarkMail.org</a>.
+		<a href="https://lists.apache.org/list.html?dev@fineract.apache.org" target="_blank">on lists.apache.org</a>.
         </p>
         <h5>Commits</h5>
         <p class="flow-text">


### PR DESCRIPTION
it has been discontinued