### PR TITLE
Fix ASF site-check footer compliance (License, Thanks, Privacy, Copyright)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1089,17 +1089,21 @@
               <i class="material-icons">language</i>
               <span>The Apache Software Foundation</span>
             </a>
-            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
-              <i class="material-icons">gavel</i>
+            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/licenses/" target="_blank">
+              <span class="material-icons icon-sr-only" aria-hidden="true">gavel</span>
               <span>License</span>
             </a>
-            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">
+            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/sponsors.html" target="_blank">
               <i class="material-icons">volunteer_activism</i>
-              <span>Sponsorship</span>
+              <span>Sponsor</span>
             </a>
             <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/thanks.html" target="_blank">
-              <i class="material-icons">favorite</i>
+              <span class="material-icons icon-sr-only" aria-hidden="true">favorite</span>
               <span>Thanks</span>
+            </a>
+            <a class="ref-link waves-effect waves-light" href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank">
+              <i class="material-icons">privacy_tip</i>
+              <span>Privacy</span>
             </a>
             <a class="ref-link waves-effect waves-light" href="https://www.apache.org/security/" target="_blank">
               <i class="material-icons">security</i>
@@ -1116,11 +1120,10 @@
 
         <div class="divider divider-inverse"></div>
 
-        <div class="copyright center-align white-text">
+        <div class="site-footer-legal center-align white-text">
           <p>
-            &copy; 2009 - <span id="current-year">2020</span>&nbsp;
-            <a class="white-text" href="https://apache.org/" target="_blank">The Apache Software Foundation</a>. 
-            Licensed under the <a class="white-text" href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.
+            <a class="white-text" href="https://www.apache.org/" target="_blank">Copyright &copy; 2009 - <span id="current-year">2020</span> The Apache Software Foundation</a>.
+            Licensed under the <a class="white-text" href="https://www.apache.org/licenses/" target="_blank">Apache License, Version 2.0</a>.
           </p>
           <p>
             Apache Fineract, Fineract, Apache, the Apache feather, and the Apache Fineract project logo are either registered trademarks or trademarks of the Apache Software Foundation.
@@ -1218,14 +1221,14 @@
           transition: none;
         }
 
-        .copyright {
+        .site-footer-legal {
           padding: 2rem 0 1rem;
           font-size: 0.9rem;
           opacity: 0.9;
           line-height: 1.6;
         }
 
-        .copyright a {
+        .site-footer-legal a {
           text-decoration: none;
           background-image: none;
           padding-bottom: 2px;


### PR DESCRIPTION
## Summary
This PR updates the footer in `index.html` to satisfy Apache Whimsy site-check requirements while keeping the existing UI intact.

## Changes
- Updated the **License** link target to:
  - `https://www.apache.org/licenses/`
- Ensured the **Thanks** link target is valid:
  - `https://www.apache.org/foundation/thanks.html`
- Added the **Privacy** link:
  - `https://privacy.apache.org/policies/privacy-policy-public.html`
- Updated copyright text to include both `Copyright/©` and `Apache`
- Kept visible icons for **License** and **Thanks** while preventing Whimsy text-matching issues by wrapping icon text in:
  - `span.icon-sr-only` with `aria-hidden="true"`
- Renamed footer CSS selector from `.copyright` to `.site-footer-legal` to avoid false-positive copyright capture from CSS text during scan parsing

## Validation
Local Whimsy-style check output reports:
- `license=GREEN`
- `thanks=GREEN`
- `privacy=GREEN`
- `copyright=GREEN`

![Screenshot](https://github.com/user-attachments/assets/c4236ef3-4db4-41cc-b961-ac7aeb1b3430)

