### PR TITLE
Add level-one heading to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,18 @@
         padding: 0 15px;
       }
 
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
       /* Logo Styles */
       .logo-wrapper {
         display: flex;
@@ -400,6 +412,7 @@
     }
   </script>
   <main class="container">
+    <h1 class="visually-hidden">Apache Fineract</h1>
     <section class="section">
       <h3 class="center-align">Platform for Digital Financial Services</h3>
       


### PR DESCRIPTION
### Summary 

- Added an accessible level-one heading: [index.html (line 415)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/airaj/.vscode/extensions/openai.chatgpt-0.5.73-win32-x64/webview/#)
- Added a reusable visually-hidden utility class: [index.html (line 129)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/airaj/.vscode/extensions/openai.chatgpt-0.5.73-win32-x64/webview/#)

This resolves the page must contain an  h1 issue while preserving the visible layout.