### PR TITLE
fix: use ASF sponsorship link for footer compliance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,9 +1106,9 @@
               <span class="material-icons icon-sr-only" aria-hidden="true">gavel</span>
               <span>License</span>
             </a>
-            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/sponsors.html" target="_blank">
+            <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">
               <i class="material-icons">volunteer_activism</i>
-              <span>Sponsor</span>
+              <span>Sponsorship</span>
             </a>
             <a class="ref-link waves-effect waves-light" href="https://www.apache.org/foundation/thanks.html" target="_blank">
               <span class="material-icons icon-sr-only" aria-hidden="true">favorite</span>


### PR DESCRIPTION
### Summary:
https://whimsy.apache.org/site/project/fineract requires ^https?://.*apache.org/foundation/sponsorship
### Changes:
- Sponsorship footer now uses https://www.apache.org/foundation/sponsorship.html with link text Sponsorship