### PR TITLE
fix: prevent navbar overlap at mid-width breakpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,9 +171,38 @@
         line-height: 1.2;
         letter-spacing: 0.5px;
         text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+        white-space: nowrap;
       }
 
       /* Responsive adjustments */
+      @media only screen and (max-width: 1300px) {
+        .brand-logo {
+          transform: translateX(-50%);
+          left: 50%;
+          max-width: calc(100% - 120px);
+        }
+
+        .logo-container {
+          gap: 10px;
+        }
+
+        .logo-img {
+          height: 46px;
+        }
+
+        .brand-name {
+          font-size: 1.6rem;
+        }
+
+        .nav-links {
+          display: none !important;
+        }
+
+        .button-collapse {
+          display: block !important;
+        }
+      }
+
       @media only screen and (max-width: 992px) {
         .brand-logo {
           transform: translateX(-50%);


### PR DESCRIPTION
## Summary
Prevent navbar overlap at mid-width breakpoints by introducing responsive behavior. When the overlapping threshold is reached, the navbar automatically switches to a hamburger menu layout to maintain usability and visual consistency.

---

## Before (This is threshold)

![Before Overlap](https://github.com/user-attachments/assets/17d8985c-9075-49be-8857-425aff899cb9)

---

## After (Hamburger Menu at Overlap Threshold)

![After Overlapping Point - Hamburger Menu](https://github.com/user-attachments/assets/5e0cf5ec-5f2f-4d2d-8ce1-0899ff394be9)

---

## Mobile View

![Mobile View](https://github.com/user-attachments/assets/d83f8024-0794-4b93-b3e5-c732c7b2b4fa)
