### PR TITLE
fix: simplify theme switching with system preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1517,6 +1517,29 @@
       --danger-text: #721c24;
       --info-bg: #cce5ff;
       --info-text: #004085;
+      color-scheme: light;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme]) {
+        --primary-bg: #121212;
+        --secondary-bg: #1e1e1e;
+        --text-color: #ffffff;
+        --nav-bg: #000000;
+        --nav-text: #ffffff;
+        --card-bg: #2d2d2d;
+        --card-shadow: rgba(0, 0, 0, 0.5);
+        --link-color: #4db6ac;
+        --border-color: rgba(255, 255, 255, 0.15);
+        --hover-bg: rgba(255, 255, 255, 0.1);
+        --warning-bg: #332701;
+        --warning-text: #ffd970;
+        --danger-bg: #2c0b0e;
+        --danger-text: #f8d7da;
+        --info-bg: #002752;
+        --info-text: #9fcdff;
+        color-scheme: dark;
+      }
     }
 
     [data-theme="dark"] {
@@ -1536,6 +1559,7 @@
       --danger-text: #f8d7da;
       --info-bg: #002752;
       --info-text: #9fcdff;
+      color-scheme: dark;
     }
 
     /* Additional Dark Mode Specific Styles */
@@ -1600,28 +1624,57 @@
     }
   </style>
   <script>
-    // Theme Toggle Functionality
-    function toggleTheme() {
-      const html = document.documentElement;
-      const currentTheme = html.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      
-      html.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      // Update icon and text
-      const themeIcon = document.querySelector('.theme-toggle i');
-      const themeText = document.querySelector('.theme-text');
-      themeText.textContent = newTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    const DARK_THEME = 'dark';
+    const LIGHT_THEME = 'light';
+    let manualThemeOverride = false;
+
+    function getSystemTheme() {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? DARK_THEME
+        : LIGHT_THEME;
     }
 
-    // Set Initial Theme
+    function updateThemeControl(theme) {
+      const toggle = document.querySelector('.theme-toggle');
+      const themeIcon = toggle ? toggle.querySelector('i') : null;
+      if (!toggle || !themeIcon) {
+        return;
+      }
+      themeIcon.textContent = theme === DARK_THEME ? 'light_mode' : 'dark_mode';
+      toggle.setAttribute('title', theme === DARK_THEME ? 'Theme: Dark' : 'Theme: Light');
+      toggle.setAttribute('aria-label', theme === DARK_THEME ? 'Theme: dark' : 'Theme: light');
+    }
+
+    function applyTheme(theme) {
+      document.documentElement.setAttribute('data-theme', theme);
+      updateThemeControl(theme);
+    }
+
+    function toggleTheme() {
+      const currentTheme = document.documentElement.getAttribute('data-theme') === DARK_THEME
+        ? DARK_THEME
+        : LIGHT_THEME;
+      const nextTheme = currentTheme === DARK_THEME ? LIGHT_THEME : DARK_THEME;
+      manualThemeOverride = true;
+      applyTheme(nextTheme);
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
-      const savedTheme = localStorage.getItem('theme') || 'light';
-      document.documentElement.setAttribute('data-theme', savedTheme);
-      
-      const themeText = document.querySelector('.theme-text');
-      themeText.textContent = savedTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+      manualThemeOverride = false;
+      applyTheme(getSystemTheme());
+
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      const handleThemeChange = function() {
+        if (!manualThemeOverride) {
+          applyTheme(getSystemTheme());
+        }
+      };
+
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleThemeChange);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(handleThemeChange);
+      }
     });
   </script>
   <style>
@@ -1729,30 +1782,6 @@
   }
   </style>
 
-  <script>
-    // Theme Toggle Functionality
-    function toggleTheme() {
-      const html = document.documentElement;
-      const currentTheme = html.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      const themeIcon = document.querySelector('.theme-toggle i');
-      
-      html.setAttribute('data-theme', newTheme);
-      localStorage.setItem('theme', newTheme);
-      
-      // Update icon based on theme
-      themeIcon.textContent = newTheme === 'dark' ? 'light_mode' : 'dark_mode';
-    }
-
-    // Set Initial Theme
-    document.addEventListener('DOMContentLoaded', function() {
-      const savedTheme = localStorage.getItem('theme') || 'light';
-      const themeIcon = document.querySelector('.theme-toggle i');
-      
-      document.documentElement.setAttribute('data-theme', savedTheme);
-      themeIcon.textContent = savedTheme === 'dark' ? 'light_mode' : 'dark_mode';
-    });
-  </script>
   <style>
     /* Subtle fade-in animation for sections */
     .section {


### PR DESCRIPTION
## Summary
Simplified theme behavior on the Fineract site to follow browser/system preference by default, while keeping manual toggle support during the current session.

## What changed
- Removed localStorage-based theme persistence.
- On page load, theme now always starts from browser/OS preference (`prefers-color-scheme`).
- Manual toggle still switches between dark/light and updates the icon correctly.
- On browser reopen/reload, site returns to system theme (as requested).
- Consolidated duplicate theme scripts into one clean implementation.

## Fixed error
This also fixes the runtime error:

`(index):1624 Uncaught TypeError: Cannot set properties of null (setting 'textContent')`

### Root cause
Old code attempted to update `.theme-text` even when that element did not exist.

### Fix
- Removed `.theme-text` update path.
- Added safe icon update flow that checks toggle/icon elements before setting `textContent`.

## Behavior now
- Browser dark -> site dark on load.
- Browser light -> site light on load.
- Manual toggle changes theme immediately and icon updates.
- Close/reopen browser -> site again follows system preference.

https://github.com/user-attachments/assets/9357011d-4b33-4886-9099-08ef716736c3

