### PR TITLE
FINERACT-2600: Fix theme toggle scrolling page to top on click

### DIFF
--- a/css/fineract.css
+++ b/css/fineract.css
@@ -455,6 +455,8 @@ main.container .collection .collection-item:last-child,
   cursor: pointer;
   opacity: 1;
   transition: opacity 0.2s ease;
+  background: transparent;
+  border: 0;
 }
 
 .theme-toggle i {

--- a/css/fineract.css
+++ b/css/fineract.css
@@ -471,6 +471,10 @@ main.container .collection .collection-item:last-child,
   opacity: 0.9;
 }
 
+.theme-toggle:focus {
+  background: transparent;
+}
+
 /* Solution Providers section */
 .solution-providers {
   padding: 3rem 0;

--- a/site-src/layouts/partials/home-header.html
+++ b/site-src/layouts/partials/home-header.html
@@ -26,9 +26,9 @@
             </li>
             {{- end }}
             <li>
-              <a class="nav-link theme-toggle" href="#" onclick="toggleTheme()" aria-label="Toggle theme">
+              <button type="button" class="nav-link theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
                 <i class="material-icons">dark_mode</i>
-              </a>
+              </button>
             </li>
           </ul>
 


### PR DESCRIPTION
## Summary

Replace the theme toggle anchor (`<a href="#">`) with a `<button type="button">`, and reset background and border in CSS so the visual is identical to before.

## Why

JIRA: [FINERACT-2600](https://issues.apache.org/jira/browse/FINERACT-2600)

Clicking the toggle scrolled the page to top because `href="#"` triggered default anchor navigation. `<button>` is also semantically correct since the toggle doesn't navigate anywhere, and Space-key activation works for free.

## Testing

Served locally and verified the bug reproduces with the original markup, then no longer reproduces after the change. Toggled multiple times across scrolled positions, theme switches in place. Visual rendering identical to before. Tested in Safari, Chrome, and Firefox.