### PR TITLE
require 0 approving reviews to merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,4 +20,4 @@ github:
       required_linear_history: false
       required_conversation_resolution: true
       required_pull_request_reviews:
-        required_approving_review_count: 1
+        required_approving_review_count: 0


### PR DESCRIPTION
`.github/workflows/site-publish.yml` is currently broken. I'm hoping this will fix it.

We don't need the same level of rigor as the apache/fineract repo, and I'd like to keep the existing site publish workflow in place.